### PR TITLE
Fix compilation errors

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use lamedh_http::handler;
 use lamedh_runtime::run;
-use rocket::Rocket;
+use rocket::{Build, Rocket};
 use tokio::sync::Mutex;
 
 use crate::config::*;
@@ -11,7 +11,7 @@ use crate::LazyClient;
 
 /// A builder to create and configure a [RocketHandler](RocketHandler).
 pub struct RocketHandlerBuilder {
-    rocket: Rocket,
+    rocket: Rocket<Build>,
     config: Config,
 }
 
@@ -25,7 +25,7 @@ impl RocketHandlerBuilder {
     ///
     /// let builder = RocketHandlerBuilder::new(rocket::ignite());
     /// ```
-    pub fn new(rocket: rocket::Rocket) -> RocketHandlerBuilder {
+    pub fn new(rocket: Rocket<Build>) -> RocketHandlerBuilder {
         RocketHandlerBuilder {
             rocket,
             config: Config::default(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,9 +5,10 @@ use std::sync::Arc;
 use aws_lambda_events::encodings::Body;
 use lamedh_http::{Handler, Request, RequestExt, Response};
 use lamedh_runtime::Context;
-use rocket::http::{uri::Uri, Header};
+use rocket::http::Header;
+use rocket::http::RawStr;
 use rocket::local::asynchronous::{Client, LocalRequest, LocalResponse};
-use rocket::{Rocket, Route};
+use rocket::{Build, Rocket, Route};
 use tokio::sync::Mutex;
 
 use crate::config::*;
@@ -21,7 +22,7 @@ pub struct RocketHandler {
 }
 
 pub(super) enum LazyClient {
-    Uninitialized(Option<Rocket>),
+    Uninitialized(Option<Rocket<Build>>),
     Ready(Arc<Client>),
 }
 
@@ -61,8 +62,8 @@ fn get_path_and_query(config: &Config, req: &Request) -> String {
             uri.push_str(&format!(
                 "{}{}={}",
                 separator,
-                Uri::percent_encode(key),
-                Uri::percent_encode(value)
+                RawStr::new(key).percent_encode(),
+                RawStr::new(value).percent_encode()
             ));
             separator = '&';
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ async fn main() {
 
 #![allow(clippy::large_enum_variant)]
 
-use rocket::Rocket;
+use rocket::{Build, Rocket};
 
 #[macro_use]
 extern crate failure;
@@ -59,7 +59,7 @@ pub trait RocketExt {
     fn lambda(self) -> RocketHandlerBuilder;
 }
 
-impl RocketExt for Rocket {
+impl RocketExt for Rocket<Build> {
     fn lambda(self) -> RocketHandlerBuilder {
         RocketHandlerBuilder::new(self)
     }


### PR DESCRIPTION
Updates to Rocket master have changed the signature for the Rocket struct and removed the Uri::percent_encode function.
Rocket has been changed to Rocket<Build>.
Uri::percent_encode(...) has been changed to RawStr::new(...).percent_encode().